### PR TITLE
feat: JWT 생성 시, 역할 정보 추가

### DIFF
--- a/src/main/java/com/connect/skilltrade/security/domain/Role.java
+++ b/src/main/java/com/connect/skilltrade/security/domain/Role.java
@@ -1,0 +1,16 @@
+package com.connect.skilltrade.security.domain;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum Role {
+
+    USER("일반 사용자"),
+    EXPERT("전문가"),
+    ADMIN("관리자")
+    ;
+
+    private final String description;
+}

--- a/src/main/java/com/connect/skilltrade/security/domain/SecurityExceptionStatus.java
+++ b/src/main/java/com/connect/skilltrade/security/domain/SecurityExceptionStatus.java
@@ -9,7 +9,8 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum SecurityExceptionStatus implements ExceptionStatus {
 
-    ACCESS_TOKEN_CLAIMS_NULL(HttpStatus.BAD_REQUEST, "엑세스 토큰에 포함될 정보는 null일 수 없습니다.", 101)
+    ACCESS_TOKEN_SUBJECT_NULL(HttpStatus.BAD_REQUEST, "엑세스 토큰에 포함될 Subject 정보는 null일 수 없습니다.", 101),
+    ACCESS_TOKEN_ROLE_CLAIM_NULL(HttpStatus.BAD_REQUEST, "엑세스 토큰에 포함될 역할 정보는 null 또는 빈 값일 수 없습니다.", 107),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/connect/skilltrade/security/domain/TokenGenerator.java
+++ b/src/main/java/com/connect/skilltrade/security/domain/TokenGenerator.java
@@ -1,6 +1,8 @@
 package com.connect.skilltrade.security.domain;
 
+import java.util.List;
+
 public interface TokenGenerator {
 
-    Token generateToken(Long id);
+    Token generateToken(Long id, List<Role> roles);
 }

--- a/src/test/java/com/connect/skilltrade/security/infrastructure/JwtProviderTest.java
+++ b/src/test/java/com/connect/skilltrade/security/infrastructure/JwtProviderTest.java
@@ -1,11 +1,16 @@
 package com.connect.skilltrade.security.infrastructure;
 
 import com.connect.skilltrade.common.exception.BusinessException;
+import com.connect.skilltrade.security.domain.Role;
 import com.connect.skilltrade.security.domain.SecurityExceptionStatus;
 import com.connect.skilltrade.security.domain.Token;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -17,6 +22,7 @@ class JwtProviderTest {
     private JwtProvider jwtProvider;
 
     private static final long USER_ID = -1L;
+    private static final List<Role> ROLES = List.of(Role.EXPERT, Role.USER);
     private static final String SECRET = "7YWM7Iqk7Yq4IOy9lOuTnOyXkOyEnCDsgqzsmqntlaAgSldUIOyLnO2BrOumvw==";
     private static final long ACCESS_TOKEN_VALIDITY_TIME = 1L;
     private static final long REFRESH_TOKEN_VALIDITY_TIME = 3L;
@@ -30,7 +36,7 @@ class JwtProviderTest {
     @Test
     void successGenerateToken() {
         // when
-        Token result = jwtProvider.generateToken(USER_ID);
+        Token result = jwtProvider.generateToken(USER_ID, ROLES);
 
         // then
         assertThat(result).isNotNull();
@@ -44,8 +50,19 @@ class JwtProviderTest {
     void failGenerateToken_userIdIsNull() {
         // when
         // then
-        assertThatThrownBy(() -> jwtProvider.generateToken(null))
+        assertThatThrownBy(() -> jwtProvider.generateToken(null, ROLES))
                 .isInstanceOf(BusinessException.class)
-                .hasMessage(SecurityExceptionStatus.ACCESS_TOKEN_CLAIMS_NULL.getMessage());
+                .hasMessage(SecurityExceptionStatus.ACCESS_TOKEN_SUBJECT_NULL.getMessage());
+    }
+
+    @DisplayName("사용자 역할이 null 또는 빈 값인 경우, JWT 생성 시 예외 발생")
+    @ParameterizedTest
+    @NullAndEmptySource
+    void failGenerateToken_rolesIsNull(List<Role> roles) {
+        // when
+        // then
+        assertThatThrownBy(() -> jwtProvider.generateToken(USER_ID, roles))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage(SecurityExceptionStatus.ACCESS_TOKEN_ROLE_CLAIM_NULL.getMessage());
     }
 }


### PR DESCRIPTION
## 📝작업 내용

- JWT 생성 시, 사용자의 역할 정보 추가
- 사용자 ID는 Claim 정보에서 Subject 정보로 저장하는 로직으로 수정
